### PR TITLE
Enable selection of Chinese encoding variants

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -120,6 +120,15 @@ encodings =
   gbk:
     list:   'Chinese (GBK)'
     status: 'GBK'
+  gb18030:
+    list:   'Chinese (GB18030)'
+    status: 'GB18030'
+  cp950:
+    list:   'Traditional Chinese (Big5)'
+    status: 'Big5'
+  big5hkscs:
+    list:   'Traditional Chinese (Big5-HKSCS)'
+    status: 'Big5-HKSCS'
   shiftjis:
     list:   'Japanese (Shift JIS)'
     status: 'Shift JIS'


### PR DESCRIPTION
`Big5`, `Big5HKSCS`,  `GB18030` are still commonly seen in the wild, especially when dealing with government- and personal-owned websites developed on Windows machines. This patch enables these encodings for selection.

Encoding names cited from [ashtuchkin/iconv-lite](https://github.com/ashtuchkin/iconv-lite/).
