### PR TITLE
Change linux keymap to match others

### DIFF
--- a/keymaps/encoding-selector.cson
+++ b/keymaps/encoding-selector.cson
@@ -5,4 +5,4 @@
   'ctrl-shift-u': 'encoding-selector:show'
 
 '.platform-linux .editor':
-  'ctrl-shift-u': 'encoding-selector:show'
+  'alt-u': 'encoding-selector:show'

--- a/keymaps/encoding-selector.cson
+++ b/keymaps/encoding-selector.cson
@@ -5,4 +5,4 @@
   'ctrl-shift-u': 'encoding-selector:show'
 
 '.platform-linux .editor':
-  'ctrl-u': 'encoding-selector:show'
+  'ctrl-shift-u': 'encoding-selector:show'


### PR DESCRIPTION
I changed it to `ctrl-shift-u`.  I did a search in https://github.com/atom/atom/blob/master/keymaps/linux.cson and didn't see a conflict.  Normally I would use keybinding resolver, but not on Linux right now.