### PR TITLE
Remove Change Encoding from mini editor context menu

### DIFF
--- a/menus/encoding-selector.cson
+++ b/menus/encoding-selector.cson
@@ -7,7 +7,7 @@
 ]
 
 'context-menu':
-  'atom-text-editor': [
+  'atom-text-editor:not([mini])': [
     'label': 'Change Encoding'
     'command': 'encoding-selector:show'
   ]


### PR DESCRIPTION
Part of atom/settings-view#354

This removes Change Encoding from mini editors' context menus - if this is a bit too far-reaching I can limit it to mini editors in panes without file paths, but the current behavior is confusing.