### PR TITLE
Update linux keyboard shortcut to match others

### DIFF
--- a/keymaps/encoding-selector.cson
+++ b/keymaps/encoding-selector.cson
@@ -5,4 +5,4 @@
   'ctrl-shift-u': 'encoding-selector:show'
 
 '.platform-linux atom-text-editor':
-  'alt-u': 'encoding-selector:show'
+  'ctrl-shift-u': 'encoding-selector:show'


### PR DESCRIPTION
`alt-u` conflicts with the gif-diff-details package and `ctrl-shift-u` doesn't seem to be used by any other core Atom packages.