### PR TITLE
add a tooltip to the encoding status view

### DIFF
--- a/lib/encoding-status-view.js
+++ b/lib/encoding-status-view.js
@@ -69,10 +69,10 @@ export default class EncodingStatusView {
         this.encodingLink.dataset.encoding = editorEncoding
         this.element.style.display = ''
 
-        if(this.tooltip) {
+        if (this.tooltip) {
           this.tooltip.dispose()
         }
-        this.tooltip = atom.tooltips.add(this.encodingLink, {title: 'File displayed using ' + encodingLabel.list + ' encoding'})
+        this.tooltip = atom.tooltips.add(this.encodingLink, {title: `This file uses ${encodingLabel.list} encoding`})
       } else {
         this.element.style.display = 'none'
       }

--- a/lib/encoding-status-view.js
+++ b/lib/encoding-status-view.js
@@ -38,8 +38,8 @@ export default class EncodingStatusView {
       this.tile.destroy()
     }
 
-    if (this.toolTip) {
-      this.toolTip.dispose()
+    if (this.tooltip) {
+      this.tooltip.dispose()
     }
   }
 
@@ -69,10 +69,10 @@ export default class EncodingStatusView {
         this.encodingLink.dataset.encoding = editorEncoding
         this.element.style.display = ''
 
-        if(this.toolTip) {
-          this.toolTip.dispose()
+        if(this.tooltip) {
+          this.tooltip.dispose()
         }
-        this.toolTip = atom.tooltips.add(this.encodingLink, {title: 'File displayed using ' + encodingLabel.list + ' encoding'})
+        this.tooltip = atom.tooltips.add(this.encodingLink, {title: 'File displayed using ' + encodingLabel.list + ' encoding'})
       } else {
         this.element.style.display = 'none'
       }

--- a/lib/encoding-status-view.js
+++ b/lib/encoding-status-view.js
@@ -37,6 +37,10 @@ export default class EncodingStatusView {
     if (this.tile) {
       this.tile.destroy()
     }
+
+    if (this.toolTip) {
+      this.toolTip.dispose()
+    }
   }
 
   attach () {
@@ -64,6 +68,11 @@ export default class EncodingStatusView {
         this.encodingLink.textContent = encodingLabel.status
         this.encodingLink.dataset.encoding = editorEncoding
         this.element.style.display = ''
+
+        if(this.toolTip) {
+          this.toolTip.dispose()
+        }
+        this.toolTip = atom.tooltips.add(this.encodingLink, {title: 'This file uses ' + encodingLabel.list + ' encoding'})
       } else {
         this.element.style.display = 'none'
       }

--- a/lib/encoding-status-view.js
+++ b/lib/encoding-status-view.js
@@ -72,7 +72,7 @@ export default class EncodingStatusView {
         if(this.toolTip) {
           this.toolTip.dispose()
         }
-        this.toolTip = atom.tooltips.add(this.encodingLink, {title: 'This file uses ' + encodingLabel.list + ' encoding'})
+        this.toolTip = atom.tooltips.add(this.encodingLink, {title: 'File displayed using ' + encodingLabel.list + ' encoding'})
       } else {
         this.element.style.display = 'none'
       }


### PR DESCRIPTION
### Requirements

### Description of the Change

This PR adds a tooltip to the status bar indicator.

### Alternate Designs

No other designs were considered.  Happy to make changes.

### Benefits

Unfamiliar users will be reassured that, yes, this indicator does refer to the file being edited.

Also, most status bar items have tooltips.  This offers a bit of reassuring consistency.

### Possible Drawbacks

Maybe I'll leak the tooltip if I missed a place where it needs to be disposed?

### Applicable Issues

#26 
