### PR TITLE
Make the encoding label unfocusable to properly restore focus

### DIFF
--- a/lib/encoding-status-view.js
+++ b/lib/encoding-status-view.js
@@ -10,7 +10,6 @@ export default class EncodingStatusView {
     this.element.classList.add('encoding-status', 'inline-block')
     this.encodingLink = document.createElement('a')
     this.encodingLink.classList.add('inline-block')
-    this.encodingLink.href = '#'
     this.element.appendChild(this.encodingLink)
     this.activeItemSubscription = atom.workspace.observeActivePaneItem(this.subscribeToActiveTextEditor.bind(this))
     const clickHandler = (event) => {


### PR DESCRIPTION

### Description of the Change
Make the encoding label unfocusable.
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

<!-- What benefits will be realized by the code change? -->
We can restore the focus onto the focused element before clicking rather than the encoding label, which in my opinion is desirable in most cases. This change also aligns with behavior of **grammar-selector**.
### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
Cannot navigate through tabs. But the navigation actually doesn't make sense since we cannot use `Enter` when focusing.
### Applicable Issues

<!-- Enter any applicable Issues here -->
Part of https://github.com/atom/status-bar/issues/82