### PR TITLE
Restore ability to display encoding for pending text editor panes

### DIFF
--- a/lib/encoding-status-view.js
+++ b/lib/encoding-status-view.js
@@ -12,7 +12,14 @@ export default class EncodingStatusView {
     this.encodingLink.classList.add('inline-block')
     this.encodingLink.href = '#'
     this.element.appendChild(this.encodingLink)
-    this.activeItemSubscription = atom.workspace.observeActivePaneItem(this.subscribeToActiveTextEditor.bind(this))
+
+    // TODO[v1.19]: Remove conditional once atom.workspace.observeActiveTextEditor ships in Atom v1.19
+    if (atom.workspace.observeActiveTextEditor) {
+      this.activeItemSubscription = atom.workspace.observeActiveTextEditor(this.subscribeToActiveTextEditor.bind(this))
+    } else {
+      this.activeItemSubscription = atom.workspace.observeActivePaneItem(this.subscribeToActiveTextEditor.bind(this))
+    }
+
     const clickHandler = (event) => {
       event.preventDefault()
       atom.commands.dispatch(atom.workspace.getActiveTextEditor().element, 'encoding-selector:show')


### PR DESCRIPTION
### Description of the Change

As one part of resolving https://github.com/atom/status-bar/issues/194, this pull request updates this package to take advantage of the new `Workspace::observeActiveTextEditor(callback)` API being introduced in https://github.com/atom/atom/pull/14695.

### Alternate Designs

See https://github.com/atom/atom/pull/14695

### Benefits

The package will regain the ability to display the file encoding for pending text editor panes.

### Possible Drawbacks

See https://github.com/atom/atom/pull/14695

### Applicable Issues

- https://github.com/atom/atom/issues/14648
- https://github.com/atom/status-bar/issues/194

### Demo

#### Before

![encoding-selector-before](https://cloud.githubusercontent.com/assets/2988/26749519/ea39af26-47da-11e7-97a2-86b2e0045602.gif)

#### After

![encoding-selector-after](https://cloud.githubusercontent.com/assets/2988/26749526/ed2a86ba-47da-11e7-8ca1-bc6c93205895.gif)
