### PR TITLE
Remove obsolete conditional re: `atom.workspace.observeActiveTextEditor`

### DIFF
--- a/lib/encoding-status-view.js
+++ b/lib/encoding-status-view.js
@@ -13,13 +13,7 @@ export default class EncodingStatusView {
     this.encodingLink.href = '#'
     this.element.appendChild(this.encodingLink)
 
-    // TODO[v1.19]: Remove conditional once atom.workspace.observeActiveTextEditor ships in Atom v1.19
-    if (atom.workspace.observeActiveTextEditor) {
-      this.activeItemSubscription = atom.workspace.observeActiveTextEditor(this.subscribeToActiveTextEditor.bind(this))
-    } else {
-      this.activeItemSubscription = atom.workspace.observeActivePaneItem(this.subscribeToActiveTextEditor.bind(this))
-    }
-
+    this.activeItemSubscription = atom.workspace.observeActiveTextEditor(this.subscribeToActiveTextEditor.bind(this))
     const clickHandler = (event) => {
       event.preventDefault()
       atom.commands.dispatch(atom.workspace.getActiveTextEditor().element, 'encoding-selector:show')


### PR DESCRIPTION
This PR removes the conditional logic (originally introduced in https://github.com/atom/encoding-selector/pull/49) that tested for the existence of `atom.workspace.observeActiveTextEditor`. Now that Atom 1.19 has been released, we can safely expect `atom.workspace.observeActiveTextEditor` to be available: https://github.com/atom/atom/blob/v1.19.0/src/workspace.js#L665-L675
