### PR TITLE
Unflake a test

### DIFF
--- a/spec/encoding-selector-spec.coffee
+++ b/spec/encoding-selector-spec.coffee
@@ -74,7 +74,11 @@ describe "EncodingSelector", ->
         encodingStatus.offsetHeight > 0
 
     it "displays the name of the current encoding", ->
-      expect(encodingStatus.querySelector('a').textContent).toBe 'UTF-8'
+      waitsFor ->
+        encodingStatus.querySelector('a').textContent.length isnt 0
+
+      runs ->
+        expect(encodingStatus.querySelector('a').textContent).toBe 'UTF-8'
 
     it "hides the label when the current encoding is null", ->
       spyOn(editor, 'getEncoding').andReturn null


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This approach works, but I'm not sure if it's the best solution, because I don't know what `atom.views.updateDocument` is for.  Removing that function seemed to fix the flake as well.

### Alternate Designs

See above.

### Benefits

One less flake.

### Applicable Issues

Fixes #54