### PR TITLE
On windows, exclude encodings that don't work

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -58,10 +58,6 @@ const encodings = {
     list: 'Baltic (ISO 8859-4)',
     status: 'ISO 8859-4'
   },
-  iso885914: {
-    list: 'Celtic (ISO 8859-14)',
-    status: 'ISO 8859-14'
-  },
   windows1250: {
     list: 'Central European (Windows 1250)',
     status: 'Windows 1250'
@@ -109,10 +105,6 @@ const encodings = {
   iso88598: {
     list: 'Hebrew (ISO 8859-8)',
     status: 'ISO 8859-8'
-  },
-  iso885910: {
-    list: 'Nordic (ISO 8859-10)',
-    status: 'ISO 8859-10'
   },
   iso885916: {
     list: 'Romanian (ISO 8859-16)',
@@ -164,12 +156,27 @@ const encodings = {
   }
 }
 
+const posixOnlyEncodings = {
+  iso885914: {
+    list: 'Celtic (ISO 8859-14)',
+    status: 'ISO 8859-14'
+  },
+  iso885910: {
+    list: 'Nordic (ISO 8859-10)',
+    status: 'ISO 8859-10'
+  }
+}
+
 let encodingListView = null
 let encodingStatusView = null
 let commandSubscription = null
 
 module.exports = {
   activate () {
+    if (process.platform !== 'win32') {
+      Object.assign(encodings, posixOnlyEncodings)
+    }
+
     commandSubscription = atom.commands.add('atom-text-editor', 'encoding-selector:show', () => {
       if (!encodingListView) encodingListView = new EncodingListView(encodings)
       encodingListView.toggle()


### PR DESCRIPTION
Fixes https://github.com/atom/atom/issues/17063

Windows's native encoding APIs don't support these two encodings.