### PR TITLE
Add Windows 874 encoding for supporting Thai language

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -54,6 +54,10 @@ const encodings = {
     list: 'Baltic (Windows 1257)',
     status: 'Windows 1257'
   },
+  windows874: {
+    list: 'Thai (Windows 874)',
+    status: 'Windows 874'
+  },
   iso88594: {
     list: 'Baltic (ISO 8859-4)',
     status: 'ISO 8859-4'

--- a/lib/main.js
+++ b/lib/main.js
@@ -54,10 +54,6 @@ const encodings = {
     list: 'Baltic (Windows 1257)',
     status: 'Windows 1257'
   },
-  windows874: {
-    list: 'Thai (Windows 874)',
-    status: 'Windows 874'
-  },
   iso88594: {
     list: 'Baltic (ISO 8859-4)',
     status: 'ISO 8859-4'
@@ -157,6 +153,10 @@ const encodings = {
   euckr: {
     list: 'Korean (EUC-KR)',
     status: 'EUC-KR'
+  },
+  windows874: {
+    list: 'Thai (Windows 874)',
+    status: 'Windows 874'
   }
 }
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Add Windows 874 encoding to selector list

### Alternate Designs

Use another editor to convert file and save. Then reopen in Atom

### Benefits

Support old Thai language projects

### Possible Drawbacks

I don't see any possible drawback

### Applicable Issues

https://github.com/atom/encoding-selector/issues/41