### PR TITLE
Fix labels of Vietnamese (Windows-1258) encoding

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -119,8 +119,8 @@ const encodings = {
     status: 'ISO 8859-9'
   },
   windows1258: {
-    list: 'Vietnamese (Windows 1254)',
-    status: 'Windows 1254'
+    list: 'Vietnamese (Windows 1258)',
+    status: 'Windows 1258'
   },
   gbk: {
     list: 'Chinese (GBK)',


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Adjust labels of the `windows1258` (Vietnamese) encoding to refer to 'Windows 1258' (Vietnamese) rather than 'Windows 1254' (Turkish).

### Alternate Designs

None

### Benefits

The `windows1258` encoding will get displayed to users referring to the correct Windows code page 'Windows 1258'.

### Possible Drawbacks

None

### Applicable Issues

None
